### PR TITLE
Fixed Openness section view in light/dark mode

### DIFF
--- a/components/Commit/CommitLayout.jsx
+++ b/components/Commit/CommitLayout.jsx
@@ -77,7 +77,7 @@ function FixedSidebar({ main, footer }) {
 export default function CommitLayout({ children }) {
   return (
     <div className="pb-20">
-      <div className="flex min-h-full flex-col bg-white dark:bg-gray-950">
+      <div className="flex min-h-full flex-col bg-gray-950">
         <FixedSidebar main={<Intro />} footer={<IntroFooter />} />
       </div>
     </div>


### PR DESCRIPTION
Fixes #26 

This is how the section looks like in light/dark mode now

![image](https://github.com/user-attachments/assets/7c991ec3-b406-4c59-8638-58502b423301)
