### PR TITLE
Fix Contact Section Scrolling Issue in Production

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -17,25 +17,20 @@ export default function Footer() {
   ];
 
   const handleNavigation = (href: string) => {
-    if (href.includes("#")) {
-      const [page, section] = href.split("#");
-
-      if (path === page) {
-        document
-          .getElementById(section)
-          ?.scrollIntoView({ behavior: "smooth" });
-      } else {
-        router.push(page);
-        setTimeout(() => {
-          document
-            .getElementById(section)
-            ?.scrollIntoView({ behavior: "smooth" });
-        }, 100); // Adding a small delay to ensure the page has navigated
-      }
+  if (href.includes("#")) {
+    let [page, section] = href.split("#");
+    if (!page) page = "/"; // Ensure page is "/" if empty
+    if (path === page) {
+      // On-page navigation: scroll directly
+      document.getElementById(section)?.scrollIntoView({ behavior: "smooth" });
     } else {
-      router.push(href);
+      // Off-page: push URL with query parameter for the global scroll handler
+      router.push(page + "?scrollTo=" + section);
     }
-  };
+  } else {
+    router.push(href);
+  }
+};
 
   const socialLinks = [
     {

--- a/components/ScrollToQuery.tsx
+++ b/components/ScrollToQuery.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+
+export default function ScrollToQuery() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const scrollTo = searchParams ? searchParams.get("scrollTo") : null;
+    if (scrollTo) {
+      // For off-page navigation we allow a delay for content to load.
+      const timer = setTimeout(() => {
+        const element = document.getElementById(scrollTo);
+        if (element) {
+          element.scrollIntoView({ behavior: "smooth" });
+          // Remove the query parameter from the URL
+          const url = new URL(window.location.href);
+          url.searchParams.delete("scrollTo");
+          window.history.replaceState(null, "", url.toString());
+        }
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [searchParams, router]);
+
+  return null;
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -167,7 +167,7 @@ export default function Header(props: { fixed?: boolean }) {
                   .getElementById(item.id)
                   ?.scrollIntoView({ behavior: "smooth" });
               } else {
-                router.push(item.page + "#" + item.id);
+                router.push(item.page + "?scrollTo=" + item.id);
               }
             }}
           >

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 import CommitLayout from "@/components/Commit/CommitLayout";
 import Header from "@/components/header";
 import Footer from "@/components/Footer";
+import ScrollToQuery from "@/components/ScrollToQuery";
 import { PrimaryFeatures } from "@/components/PrimaryFeatures";
 
 const primaryFeatures = [
@@ -156,6 +157,7 @@ export default function Home() {
       </Head>
       {/* Header */}
       <Header />
+      <ScrollToQuery />
       {/* Hero */}
       <main>
         {/* Hero section */}


### PR DESCRIPTION
# Issue Overview:

### Problem:
In production (on Vercel), the “Contact” section was not scrolling into view as expected when navigating via a link—whether from the Header or the Footer—using a hash or query parameter.

### Environment:
The issue did not manifest in the local development environment, which indicated that differences in rendering and hydration in production were contributing factors.

# Investigation and Findings:

### Reproduction:
I reproduced the issue by navigating to the homepage from other pages where the target “Contact” section was intended. The scroll behaviour was inconsistent across different navigation components (Header and Footer).

### Analysis:
It became evident that hash-based navigation was not reliably triggering the scroll behavior in production. This was primarily due to asynchronous rendering and hydration delays in the production build.

### Root Cause:
The delay in content rendering meant that the scroll action was executed too early or not at all, causing the “Contact” section to be missed.

# Resolution:

### Global Scroll Handler:
I implemented a new component, ScrollToQuery, which:

- Checks for a scrollTo query parameter in the URL.
- Waits briefly (using a timeout) to ensure that the content has loaded.
- Then scrolls smoothly to the target element.
- Finally, it cleans up the URL by removing the query parameter.

### Header Adjustments:
I modified the Header’s section navigation logic to:

- Use the query parameter approach (?scrollTo=contact) when navigating from other pages.
- Immediately scroll into view when the user is already on the homepage.
- Ensure consistent behaviour between local and production environments.

### Footer Adjustments:
The Footer’s “Contact” link was also updated to follow the same approach as the Header:

- If the user is on the same page, the link scrolls smoothly to the “Contact” section.
- If not, it pushes the URL with the scrollTo query parameter so that the global scroll handler takes effect after navigation.

# Outcome:

- The “Contact” section now reliably scrolls (or jumps) into view in production from both the Header and the Footer.
- Both on-page navigation and redirection scenarios are handled effectively.
- The solution has been thoroughly tested locally and in the deployed environment, meeting the expected behaviour.

Please let me know if you have any questions or need further clarifications 😇