### PR TITLE
Fixed responsive issue between 640-767px

### DIFF
--- a/components/PrimaryFeatures.tsx
+++ b/components/PrimaryFeatures.tsx
@@ -131,7 +131,7 @@ export function PrimaryFeatures() {
                 </TabList>
               </div>
               {/*Sliding card in Mobile view */}
-              <div className="sm:hidden mt-6 flex overflow-x-auto snap-x snap-mandatory">
+              <div className="md:hidden mt-6 flex overflow-x-auto snap-x snap-mandatory">
                 {features.map((feature, index) => (
                   <div
                     key={feature.title}


### PR DESCRIPTION
### Issue:
Fixed the responsiveness problem in the inner content of the `Empowering healthcare with Advanced Technology` section of the landing page. Fixes #65 

### Screenshots:
1) At 639px
![Screenshot 2025-03-04 154620](https://github.com/user-attachments/assets/3a026965-ea5d-49a4-a3f2-c6ac77fd1d5f)

2) At 640px
![Screenshot 2025-03-04 154635](https://github.com/user-attachments/assets/688f4a0c-a6f8-4208-a7ac-1472a11cee2a)

3) At 767px
![Screenshot 2025-03-04 154649](https://github.com/user-attachments/assets/938b1503-6eb9-4de7-9ac8-7ac2ee2039c3)

4) At 768px
![Screenshot 2025-03-04 154724](https://github.com/user-attachments/assets/581f637b-8200-4811-8cf0-5c2d7f4bb978)

### Fix:
Changed the breakpoint of the mobile component from sm to md.