### PR TITLE
Avoiding clickjacking

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,23 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)", // * - applies to all routes
+        headers: [
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors 'self'",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Added X-frame-Options and Content-Security-Policy: frame-ancestors 'self' headers to next.config.mjs file. These headers prevent the site from being embedded in an iframe by external sites. Verified by creating a test HTML file that attempts to iframe the site and the browser now successfully blocks the iframe as expected.

before changes, intentionally clickjacking.
![Screenshot 2025-06-28 212511](https://github.com/user-attachments/assets/5d4ab7ad-a8e4-43cc-a79b-d6be55f00a20)

after changes
![Screenshot 2025-06-28 212557](https://github.com/user-attachments/assets/57aedb60-d080-4d88-b25e-2253027e06e5)
